### PR TITLE
add: step4 레이아웃 완성

### DIFF
--- a/public/data/inputlist.json
+++ b/public/data/inputlist.json
@@ -1,0 +1,139 @@
+{  
+  "OutputFormat" : [
+  {
+    "id" : "txt",
+    "name" : "fixed-width text (*.txt)",
+    "value" : "txt"
+  }
+  ,
+  { 
+    "id" : "csv",
+    "name" : "comma-delimited text (*.csv)",
+    "value" : "csv"
+  },
+  {
+    "id" : "xlsx",
+    "name" : "Excel spreadsheet (*.xlsx)",
+    "value": "xlsx"
+  },
+  {
+    "id" : "txt",
+    "name" : "tab-delimited text (*.txt)",
+    "value": "txt"
+  },
+  {
+    "id": "htm",
+    "name" : "HTML table (*.htm)",
+    "value": "htm"
+  },
+  {
+    "id": "sas32",
+    "name" : "SAS Windows_32 dataset (*.sas7bdat)",
+    "value": "sas32"
+  },
+  {
+    "id": "saswin64",
+    "name" : "SAS Windows_64 dataset (*.sas7bdat)",
+    "value": "saswin64"
+  },
+  {
+    "id": "sas64",
+    "name" : "SAS Solaris_64 dataset (*.sas7bdat)",
+    "value": "sas64"
+  },
+  {
+    "id": "dbf",
+    "name" : "dBase file (*.dbf)",
+    "value": "dbf"
+  },
+  {
+    "id": "dta",
+    "name" : "STATA v14+ file (*.dta)",
+    "value": "dta"
+  },
+  {
+    "id": "sav",
+    "name" : "SPSS file (*.sav)",
+    "value": "sav"
+  }
+  ],
+  "CompressionType" : [
+    {
+      "id": "None",
+      "name" : "None",
+      "value": "None"
+    },
+    {
+      "id": "zip",
+      "name" : "zip (*.zip)",
+      "value": "zip"
+    },
+    {
+      "id": "gz",
+      "name" : "gzip (*.gz)",
+      "value": "gz"
+    }
+  ],
+  "DateFormat" : [
+    {
+      "id": "YYMMDDn8",
+      "name" :  "YYMMDDn8. (e.g. 19840725)",
+      "value": "YYMMDDn8"
+    },
+    {
+      "id": "DATE9",
+      "name" : "DATE9. (e.g. 25JUL1984)",
+      "value": "DATE9"
+    },
+    {
+      "id": "DDMMYY6",
+      "name" : "DDMMYY6. (e.g. 250784)",
+      "value": "DDMMYY6"
+    },
+    {
+      "id": "MMDDYY10",
+      "name" : "MMDDYY10. (e.g. 07/25/1984)",
+      "value": "MMDDYY10"
+    },
+    {
+      "id": "DDMMYY10",
+      "name" : "DDMMYY10. (e.g. 25/07/1984)",
+      "value": "DDMMYY10"
+    },
+    {
+      "id": "YYMMDDs10",
+      "name" : "YYMMDDs10. (e.g. 1984/07/25)",
+      "value": "YYMMDDs10"
+    }
+  ],
+  "Complist" : [
+    {
+      "id": "TICKER",
+      "value":"TICKER"
+    },
+    {
+      "id": "PERMNO",
+      "value":"PERMNO"
+    },
+    {
+      "id": "PERMCO",
+      "value":"PERMCO"
+    },
+    {  "id": "CUSIP",
+      "value":"CUSIP"
+    },
+    {
+      "id": "NCUSIP",
+      "value":"NCUSIP"
+    },
+    {
+      "id": "HSICCD",
+      "value":"HSICCD"
+    },
+    {
+      "id": "SICCD",
+      "value":"SICCD"
+    }
+  ]
+}
+

--- a/public/data/inputlistrequire.json
+++ b/public/data/inputlistrequire.json
@@ -1,0 +1,49 @@
+{  
+  "OutputFormat" : [
+    {
+      "id" : "txt",
+      "name" : "fixed-width text (*.txt)",
+      "value": "txt"
+    }
+    ,
+    { 
+      "id" : "csv",
+      "name" : "comma-delimited text (*.csv)",
+      "value": "csv"
+    },
+    {
+      "id" : "xlsx",
+      "name" : "Excel spreadsheet (*.xlsx)",
+      "value": "xlsx"
+    }
+  ],
+  "Complist" : [
+    {
+      "id": "TICKER",
+      "value":"TICKER"
+    },
+    {
+      "id": "PERMNO",
+      "value":"PERMNO"
+    },
+    {
+      "id": "PERMCO",
+      "value":"PERMCO"
+    },
+    {  "id": "CUSIP",
+      "value":"CUSIP"
+    },
+    {
+      "id": "NCUSIP",
+      "value":"NCUSIP"
+    },
+    {
+      "id": "HSICCD",
+      "value":"HSICCD"
+    },
+    {
+      "id": "SICCD",
+      "value":"SICCD"
+    }
+  ]
+}

--- a/src/Pages/CRSP.js
+++ b/src/Pages/CRSP.js
@@ -4,10 +4,17 @@ import styled from "styled-components";
 import Nav from "../Components/Nav/Nav";
 import StepOne from "./Components/CRSP/StepOne";
 import StepThree from "../Pages/Components/CRSP/StepThree";
+import StepFour from "./Components/CRSP/StepFour";
 import Footer from "../Components/Footer/Footer";
 import Search from "../Pages/Components/CRSP/Search";
 
 const CRSP = () => {
+  const onGetSubmit = (startDate, endDate, check) =>{
+    console.log(startDate, '부모1')
+    console.log(endDate, '부모2')
+    console.log(check, '부모3')
+  }
+
   return (
     <>
       <Nav />
@@ -36,12 +43,12 @@ const CRSP = () => {
             </li>
           </SideBarList>
         </CRSPSideBar>
-
         <CRSPContent>
           <CRSPTitle>CRSP Daily Stock</CRSPTitle>
-          <StepOne />
+          <StepOne  onSubmit={onGetSubmit}/>
           <Search />
           <StepThree />
+          <StepFour />
         </CRSPContent>
       </CRSPFrame>
 

--- a/src/Pages/Components/CRSP/StepFour.js
+++ b/src/Pages/Components/CRSP/StepFour.js
@@ -1,0 +1,406 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import { INPUT_LIST } from "../../../config";
+
+function StepFour() {
+  const [ list, setList ] = useState();
+  const [ check, setCheck ] = useState();
+  const [ query, setQuery ] = useState(false)
+
+  // 백엔드 통신용
+  useEffect(() => {
+    fetch(INPUT_LIST)
+    .then(res => res.json())
+    .then(res => {
+      setList(res);
+    });
+  }, [])
+
+  //백엔드 버튼 눌렀을시에 보내주는 기능
+  // useEffect(() => {
+  //   const { address, query_name } = check
+  //   fetch('',{
+  //     method: "POST",
+  //     headers: {
+  //       'Content-Type': 'application/json',
+  //     },
+  //     body: JSON.stringify({
+  //       address,
+  //       query_name,
+  //       check
+  //     })
+  //   })
+  //   .then(res => res.json())
+  //   .then(res => {
+      
+  //   })
+    
+  // })
+
+  // 포맷형식 선택기
+  const valuedetector = (e) => {
+    const { name, value } = e.target
+    setCheck({...check, [ name ] : value})
+  }
+
+  // 쿼리네임 체크박스 부분
+  const InputManage = (e) => {
+    !query? setQuery(true) : setQuery(false)
+  }
+
+  return(
+    <StepFourWrap>
+      <div>
+        <StepFourTitle>Step4 :</StepFourTitle>
+        <StepFourSub> Select query output.</StepFourSub>
+      </div>
+      <Body>
+        <Typing>
+          <Content>
+            Select the desired&nbsp;
+            <a href="/">
+              format
+            </a>
+              &nbsp;of the output file. 
+              For large data requests, select a compression type to expedite downloads.
+              If you enter your email address, you will receive an email that contains 
+              a URL to the output file when the data request is finished processing.
+          </Content>
+        </Typing>
+        <BtnWrap>
+          <LeftBTN>
+            <LeftWrap>
+              <LeftTitle>Output Format</LeftTitle>
+              {list && list.OutputFormat.map((el,idx) =>{
+                return(
+                  <LeftInputs key={idx}>
+                    <Btn
+                      type="radio"
+                      name="format"
+                      id={el.title}
+                      value={el.value}
+                      checked={el.value === (check && check.format)}
+                      autocomplete="off"
+                      onChange={valuedetector}
+                    />
+                    &nbsp;
+                    <LableName>{el.name}</LableName>
+                  </LeftInputs>
+                )
+              })}
+              </LeftWrap>
+          </LeftBTN>
+          {/* 민치호님의 요청으로 주석처리 함. */}
+          {/* <MiddleBTN>
+            <MiddleWrap>
+              <LeftTitle>Compression Type</LeftTitle>
+              {list && list.CompressionType.map((el) =>{
+                return(
+                  <LeftInputs>
+                    <Btn
+                    type="radio"
+                    name="compress"
+                    id={el.title}
+                    value={el.value}
+                    checked={el.value === (check && check.format)}
+                    autocomplete="off"
+                    onChange={valuedetector}
+                    />
+                    &nbsp;
+                    <LableName>{el.name}</LableName>
+                  </LeftInputs>
+                )
+              })}
+              </MiddleWrap>
+          </MiddleBTN>
+          <RightBTN>
+            <LeftWrap>
+              <LeftTitle>Date Format</LeftTitle>
+              {list && list.DateFormat.map((el) =>{
+                return(
+                  <LeftInputs>
+                    <Btn
+                    type="radio"
+                    name="datef"
+                    id={el.title}
+                    value={el.value}
+                    checked={el.value === (check && check.format)}
+                    autocomplete="off"
+                    onChange={valuedetector}
+                    />
+                    &nbsp;
+                    <LableName>{el.name}</LableName>
+                  </LeftInputs>
+                )
+              })}
+            </LeftWrap>
+          </RightBTN> */}
+        </BtnWrap>
+        <EmailRow>
+          <EmailWrap>
+            <EmailLabel>
+              E-Mail Address 
+              <Smalltitle>(Optional)</Smalltitle>
+            </EmailLabel>
+            <EmailTypingBox>
+              <EmailTyping
+                type="email"
+                maxlength="255"
+                name="email"
+                id="email"
+                placeholder="E-mail"
+                onChange={valuedetector}
+              />
+              {/* <EmailSendBtnWrap>
+                <EmailSendBtn 
+                  type="button"
+                  value="Edit Preferences"
+                  name="editPrefs"
+                  onClick=""
+                />
+              </EmailSendBtnWrap> */}
+            </EmailTypingBox>
+          </EmailWrap>
+          <SaveQueryWrap>
+            <SaveQueryTitle>
+              <InputBox
+                type="checkbox"
+                id="savequery"
+                name="savequery"
+                checked={ true === query}
+                onChange={InputManage}
+              />
+                &nbsp;Save this query to myWRDS
+            </SaveQueryTitle>
+            {query
+              ? <QueryName2
+                  name="query_name"
+                  id="query_name"
+                  type="text"
+                  placeholder="Query Name"
+                  onChange={valuedetector}
+                />
+              : <QueryName
+                  name="query_name"
+                  id="query_name"
+                  type="text"
+                  placeholder="Query Name"
+                  disabled="true"
+              />}
+          </SaveQueryWrap>
+        </EmailRow>
+        <SubmitBtnRow>
+          <BtnSubmin name="querysubmit">Submit Query</BtnSubmin>
+        </SubmitBtnRow>
+      </Body>
+    </StepFourWrap>
+  )
+}
+
+export default StepFour;
+
+const StepFourWrap = styled.div`
+  margin-top: 30px;
+  `;
+
+// 제목태그
+const StepFourTitle = styled.strong`
+  font-size: 20px;
+  font-weight: bold;
+`;
+const StepFourSub = styled.span`
+  font-size: 20px;
+`;
+
+//내용
+const Body = styled.div`
+  margin: 0 -15px;
+`;
+const Typing = styled.div`
+  position: relative;
+  min-height: 1px;
+  padding:0 15px;
+`;
+
+const Content = styled.p`
+  font-size: 18px;
+  line-height: 26px;
+  margin: 0 0 11.5px;
+  font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;
+`;
+
+//버튼들
+const BtnWrap = styled.div`
+  display: flex;
+`;
+
+const LeftBTN = styled(Typing)`
+  width: 33.33333%;
+  height: 100%;
+`;
+
+
+const LeftWrap = styled.dl`
+  margin-bottom: 19px;
+`;
+
+
+const LeftTitle = styled.dt`
+  font-weight: bold;
+  line-height: 1.4;
+  font-size: 16px;
+  font-family: inherit;
+`;
+
+const LeftInputs = styled.dd`
+  line-height: 1.4;
+`;
+
+const Btn = styled.input`
+  margin-top: 1px;
+  `;
+
+const LableName = styled.label`
+  font-size: 14px;
+  font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 5px;
+`;
+
+const EmailRow = styled.div`
+  display:flex;
+`;
+
+const EmailWrap = styled.div`
+  width: 50%;
+  position: relative;
+  min-height: 1px;
+  padding:0 15px;
+`;
+
+const EmailLabel = styled.label`
+  height: 32.5px;
+  margin-bottom: 0;
+  padding-top: 9px;
+  max-width: 100%;
+  font-size: 14px;
+  font-family:"Helvetica Neue", Helvetica, Arial, sans-serif;
+  display: inline-block;
+`;
+const Smalltitle = styled.small`
+  color: #686868;
+  font-style: italic;
+  font-size: 85%;
+  text-align: right;
+`;
+
+const EmailTypingBox = styled.div`
+  position: relative;
+  display: table;
+  border-collapse: separate;
+  width: 100%;
+  height: 37px;
+  padding: 8px 12p 8px;
+  font-size: 14px;
+  line-height: 1.4;
+  background-color: #fff;
+`;
+
+const EmailTyping = styled.input`
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  margin-bottom: 0;
+  height: 37px;
+  padding: 8px 12px;
+  font-size: 14px;
+  line-height: 1.4;
+  color: black;
+  background-color: #fff;
+  border: 1px solid #ccc;
+`;
+
+// const EmailSendBtnWrap = styled.span`
+//   width: 1%;
+//   position: relative;
+//   white-space: nowrap;
+// `;
+
+// const EmailSendBtn = styled.input`
+//   margin-left: -1px;
+//   position: absolute;
+//   padding: 8px 12px;
+//   color: #333333;
+//   background-color: #e7e7e7;
+//   border-color: #ccc;
+//   text-align: center;
+//   border: 1px solid transparent;
+//   white-space: nowrap;
+//   font-size: 14px;
+//   line-height: 1.4;
+
+//   &:hover{
+//     box-shadow: inset 0px 0px 4px rgba(0, 0, 0, 0.3);
+//     z-index: 2;
+//     background-color: #cecece;
+//     border-color: #adadad;
+//     transition: all 0.25s cubic-bezier(0.54, 0.06, 0.55, 0.97);
+//   }
+// `;
+
+
+const SaveQueryWrap = styled(EmailWrap)``;
+const SaveQueryTitle = styled(EmailLabel)``;
+
+const InputBox = styled.input`
+  margin-top: 1px;
+`;
+
+const QueryName = styled.input`
+  cursor: not-allowed;
+  background-color:"gray";
+  display: block;
+  width: 100%;
+  height: 37px;
+  padding: 8px 12px;
+  color: #000;
+  font-size: 14px;
+  line-height: 1.4;
+  border: 1px solid #ccc;
+  opacity: 1;
+`;
+
+const QueryName2 =styled(QueryName)`
+  cursor: text;
+  color: #000;
+  background-color: #fff;
+  border: 1px solid #ccc;
+`;
+
+//버튼
+const SubmitBtnRow = styled.div`
+  margin: 15px 0 30px;
+  padding-left: 15px;
+  height: auto;
+`;
+
+const BtnSubmin = styled.button`
+  color: #fff;
+  background-color: #154281;
+  border-color: #11376b;
+  padding: 8px 12px;
+  margin-top: 30px;
+  text-align: center;
+  vertical-align: middle;
+  cursor: pointer;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  font-size: 14px;
+  line-height: 1.4;
+  user-select: none;
+`;
+
+// const MiddleBTN = styled(LeftBTN)``;
+// const RightBTN = styled(LeftBTN)``;
+// const MiddleWrap = styled(LeftWrap)``;

--- a/src/Pages/Components/CRSP/StepOne.js
+++ b/src/Pages/Components/CRSP/StepOne.js
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import DatePicker from "react-datepicker";
+import { INPUT_LIST } from "../../../config";
 
-function StepOne() {
+function StepOne(props) {
   const date = new Date();
   const lastYear = date.getFullYear() - 1;
   const defalutYear = date.getFullYear() - 13;
@@ -11,10 +12,29 @@ function StepOne() {
   const [ mini, setMini ] = useState(false);
   const [ maxi, setMaxi ] = useState(false);
   const [ check, setCheck ] = useState("");
+  const [ comp, setComp ] = useState();
+
+  useEffect(()=> {
+    fetch(INPUT_LIST)
+      .then(res => res.json())
+      .then(res=> {
+        setComp(res)
+      })
+  },[])
+
   const valuedetector = (e) => {
-    const { value } = e.target
-    setCheck(value)
+    const { name, value } = e.target;
+    setCheck({[name] : value})
   }
+
+  //자식에서 부모 컴포넌트로 값 보내기.
+  const onFormSubmit = (e, value) => {
+    props.onGetSubmit(
+      (startDate, endDate, check)
+    )
+  };
+  console.log(endDate)
+
 
   return(
     <>
@@ -41,6 +61,7 @@ function StepOne() {
                     endDate={endDate}
                     minDate={new Date("1925-12-31")}
                     maxDate={new Date(endDate)}
+                    onSelect={()=> onFormSubmit(startDate)}
                     dateFormat="yyyy-MM-dd"
                     dropdownMode="select"
                     peekNextMonth
@@ -68,6 +89,7 @@ function StepOne() {
                     changeYear="true"
                     minDate={new Date(startDate)}
                     maxDate={new Date(`${lastYear}-12-31`)}
+                    onSelect={()=>onFormSubmit(endDate)}
                     dateFormat="yyyy-MM-dd"
                     dropdownMode="select"
                     peekNextMonth
@@ -91,90 +113,24 @@ function StepOne() {
             </div>
             <div>
               <Unorderedlist>
-                <Inputlist>
-                  <InputBtn 
-                    id="TICKER"
-                    type="radio"
-                    value="TICKER"
-                    autocomplete="off"
-                    checked={ check === "TICKER"}
-                    onChange={valuedetector}
-                  />
-                  &nbsp;
-                  <LabelName id="TICKER">TICKER</LabelName>
-                </Inputlist>
-                <Inputlist>
-                  <InputBtn 
-                    id="PERMNO"
-                    type="radio"
-                    value="PERMNO"
-                    autocomplete="off"
-                    checked={ check === "PERMNO"}
-                    onChange={valuedetector}
-                  />
-                  &nbsp;
-                  <LabelName id="PERMNO">PERMNO</LabelName>
-                </Inputlist>
-                <Inputlist>
-                  <InputBtn 
-                    id="PERMCO"
-                    type="radio"
-                    value="PERMCO"
-                    autocomplete="off"
-                    checked={ check === "PERMCO"}
-                    onChange={valuedetector}
-                  />
-                  &nbsp;
-                  <LabelName id="PERMCO">PERMCO</LabelName>
-                </Inputlist>
-                <Inputlist>
-                  <InputBtn
-                    id="CUSIP"
-                    type="radio"
-                    value="CUSIP"
-                    autocomplete="off"
-                    checked={ check === "CUSIP"}
-                    onChange={valuedetector}
-                  />
-                  &nbsp;
-                  <LabelName id="CUSIP">CUSIP</LabelName>
-                </Inputlist>
-                <Inputlist>
-                  <InputBtn
-                    id="NCUSIP"
-                    type="radio"
-                    value="NCUSIP"
-                    autocomplete="off"
-                    checked={ check === "NCUSIP"}
-                    onChange={valuedetector}
-                  />
-                  &nbsp;
-                  <LabelName id="NCUSIP">NCUSIP</LabelName>
-                </Inputlist>
-                <Inputlist>
-                  <InputBtn
-                    id="HSICCD"
-                    type="radio"
-                    value="HSICCD"
-                    autocomplete="off"
-                    checked={ check === "HSICCD"}
-                    onChange={valuedetector}
-                  />
-                  &nbsp;
-                  <LabelName id="HSICCD">HSICCD</LabelName>
-                </Inputlist>
-                <Inputlist>
-                  <InputBtn
-                    id="SICCD"
-                    type="radio"
-                    value="SICCD"
-                    autocomplete="off"
-                    checked={ check === "SICCD"}
-                    onChange={valuedetector}  
-                  />
-                  &nbsp;
-                  <LabelName id="SICCD">SICCD</LabelName>
-                </Inputlist>
+                {comp && comp.Complist.map((el, index)=> {
+                  return(
+                    <Inputlist key={index}>
+                      <InputBtn 
+                        id={el.id}
+                        name="comp"
+                        type="radio"
+                        value={el.value}
+                        autocomplete="off"
+                        checked={ check && check.comp === el.value}
+                        onChange={valuedetector}
+                        onClick={()=>onFormSubmit(comp)}
+                      />
+                      &nbsp;
+                      <LabelName id="TICKER">{el.id}</LabelName>
+                    </Inputlist>
+                  )
+                })}
               </Unorderedlist>
             </div>
           </MarginTop>

--- a/src/Pages/SignUp/Signup.js
+++ b/src/Pages/SignUp/Signup.js
@@ -2,10 +2,10 @@ import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Nav from "../../Components/Nav/Nav";
 import Footer from "../../Components/Footer/Footer";
-import { Univ_List } from "../../config";
+import { UNIV_LIST } from "../../config";
 import { withRouter } from "react-router-dom";
 import { Link } from "react-router-dom";
-import { Recapcha_Key } from "../../config";
+import { RECAPCHA_KEY } from "../../config";
 import { addMonths } from "date-fns";
 import DatePicker from "react-datepicker";
 import ReCAPTCHA from "react-google-recaptcha";
@@ -63,7 +63,7 @@ function Signup(props) {
 
   //대학교, 유저타입 백엔드통신용
   useEffect(() => {
-    fetch(`${Univ_List}`)
+    fetch(UNIV_LIST)
       .then((res) => res.json())
       .then((res) => {
         setData(res);
@@ -292,7 +292,7 @@ function Signup(props) {
                 {/* 리캡차 */}
                 <FormGroup>
                   <LabelName type="id_captcha">Captcha</LabelName>
-                  <ReCAPTCHA sitekey={`${Recapcha_Key}`} onChange={onChange} />
+                  <ReCAPTCHA sitekey={`${RECAPCHA_KEY}`} onChange={onChange} />
                 </FormGroup>
                 {/* 회원약관 */}
                 <FormGroup>
@@ -300,7 +300,7 @@ function Signup(props) {
                   <AcceptContract>
                     By submitting this form, you accept the
                     <Link className="TermsLink" to="">
-                      Terms of Use
+                    &nbsp;Terms of Use
                     </Link>
                   </AcceptContract>
                 </FormGroup>
@@ -308,7 +308,7 @@ function Signup(props) {
                 type="submit"
                 onClick={submitBtn}
                 >
-                  Register for WRDS
+                &nbsp;Register for WRDS
                 </SubmitBTN>
               </FormTag>
               <DatePicker

--- a/src/config.js
+++ b/src/config.js
@@ -2,13 +2,15 @@ export const USER_DATA_URL = "http://localhost:3000/data/data.json";
 
 export const TOP_PANEL_URL = "http://localhost:3000/data/topPanel.json";
 
-export const Univ_List = "http://localhost:3000/data/univ.json";
+export const UNIV_LIST = "http://localhost:3000/data/univ.json";
 
 export const STEPTHREE_CATEGORY = "/data/stepThreeCategory.json";
 
 export const STEPTHREE_LIST = "/data/crsptab.json";
 
-export const Recapcha_Key = "6LfOwcAZAAAAANC40MGASlYC8agRNhJz2POqyEIQ";
+export const INPUT_LIST = "http://localhost:3000/data/inputlistrequire.json";
+
+export const RECAPCHA_KEY = "6LfOwcAZAAAAANC40MGASlYC8agRNhJz2POqyEIQ";
 
 export const googleMapsApiKey = "AIzaSyDQWRJqEwj0XtcTztQLadhs4GWXQpKlyuU";
 


### PR DESCRIPTION
step4 레이아웃 완성.

- [x] 기능은 아직 구현하지 않음(구현 중)
- [x] 계속 추가로 기능구현과 리팩토링 예정(리팩토링 완료)

- 진행 완료 사항 -
- [x] email 타이핑 내용 입력값 state로 저장될 수 있게 구현.
- [x] input 버튼 클릭시 입력값에 따른 함수호출을 다르게하여 기능 구현.
- [x] 쿼리 name의 input값 부분 타이핑시에 입력값 인식하게 추가 구현.

- 수정사항 -
백엔드(민치호님)의 요청으로 인해서 
stepone의 input 버튼을 클릭시 기존 ticker만(value값) 출력되던 상황에서 {comp: ticker}로 출력되게 만듬.
stepfour도 동일하게 txt만(value값) 출력하던 {format:txt}로 저장되게 만듬.

- 진행중 - 
- [ ] submit 버튼 클릭시 제출하는 기능 구현 준비중